### PR TITLE
Pinned libgfortran to fix build with LAPACK ON on x86

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -86,8 +86,8 @@ cmake -LAH -G "Ninja"                                                     \
     -DENABLE_PRECOMPILED_HEADERS=OFF                                      \
     $CPU_DISPATCH_FLAGS                                                   \
     $OPENMP                                                               \
-    -DWITH_LAPACK=0                                                       \
-    -DHAVE_LAPACK=0                                                       \
+    -DWITH_LAPACK=1                                                       \
+    -DHAVE_LAPACK=1                                                       \
     -DLAPACK_LAPACKE_H=lapacke.h                                          \
     -DLAPACK_CBLAS_H=cblas.h                                              \
     -DWITH_EIGEN=1                                                        \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 5
+  number: 6
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
@@ -47,6 +47,7 @@ build:
   ignore_run_exports:
     - libgcc-ng
     - libstdcxx-ng
+    - libgfortran-ng
 
 requirements:
   build:
@@ -65,6 +66,7 @@ requirements:
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
+    - libgfortran-ng {{ libgfortran }}
   host:
     - python {{python}} 
     - numpy {{numpy}}
@@ -86,6 +88,7 @@ requirements:
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
+    - libgfortran-ng {{ libgfortran }}
   run:
     # Don't depend on python in the run section
     # py-opencv will depend on python
@@ -106,33 +109,36 @@ requirements:
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
+    - libgfortran-ng {{ libgfortran }}
 
 outputs:
   - name: libopencv
   - name: opencv
     build:
-      number: 4
+      number: 6
       string: py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
     requirements:
       build:
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
       host:
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
-
+        - libgfortran-ng {{ libgfortran }}
       run:
         - {{ pin_subpackage('libopencv', exact=True) }}
         - {{ pin_subpackage('py-opencv', exact=True) }}
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
 
   - name: py-opencv
     build:
-      number: 3
+      number: 6
       string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
       run_exports:
         # Should we even have this???
@@ -143,6 +149,7 @@ outputs:
       ignore_run_exports:
         - libgcc-ng
         - libstdcxx-ng
+        - libgfortran-ng
 
     requirements:
       # There is no build script, but I just want it to think
@@ -151,12 +158,14 @@ outputs:
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
       host:
         - python {{python}}
         - numpy {{numpy}}
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
       run:
         - python {{python}}
         - {{ pin_compatible('numpy') }}
@@ -164,6 +173,7 @@ outputs:
         # Use pins to control cos6/cos7 match
         - libgcc-ng  {{ libgcc }}
         - libstdcxx-ng  {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
 
 about:
   home: http://opencv.org/


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes build issue with LAPACK ON on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
