### PR TITLE
disable LAPACK temporarily

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -86,8 +86,8 @@ cmake -LAH -G "Ninja"                                                     \
     -DENABLE_PRECOMPILED_HEADERS=OFF                                      \
     $CPU_DISPATCH_FLAGS                                                   \
     $OPENMP                                                               \
-    -DWITH_LAPACK=1                                                       \
-    -DHAVE_LAPACK=1                                                       \
+    -DWITH_LAPACK=0                                                       \
+    -DHAVE_LAPACK=0                                                       \
     -DLAPACK_LAPACKE_H=lapacke.h                                          \
     -DLAPACK_CBLAS_H=cblas.h                                              \
     -DWITH_EIGEN=1                                                        \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

opencv when built with openblas v0.3.13 fails with following error:

` $PREFIX/include/lapacke.h:37:10: fatal error: lapack.h: No such file or directory`

Investigations reveal that lapack.h is indeed not part of openblas packages. 
Thus to get successful build adding change to disable LAPACK temporarily.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
