### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,10 @@ requirements:
     - {{ cdt('libxdamage') }}
     - {{ cdt('libxfixes') }}
     - {{ cdt('libxxf86vm') }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                        # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                  # [x86_64 and c_compiler_version == "7.2.*"]
+    - libgfortran-ng {{ libgfortran }}               # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - python {{python}} 
     - numpy {{numpy}}
@@ -77,6 +81,12 @@ requirements:
     - freetype {{freetype}}
     - protobuf {{ protobuf }}
     - libprotobuf {{ protobuf }}
+    # Use pins to control cos6/cos7 match
+    - libidn2  2.3.1                                 # [x86_64 and c_compiler_version == "7.2.*"]
+    - libgcc-ng  {{ libgcc }}                        # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                  # [x86_64 and c_compiler_version == "7.2.*"]
+    - libgfortran-ng {{ libgfortran }}               # [x86_64 and c_compiler_version == "7.2.*"]
+
   run:
     # Don't depend on python in the run section
     # py-opencv will depend on python
@@ -101,6 +111,16 @@ outputs:
     build:
       string: py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
     requirements:
+      build:
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                        # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                  # [x86_64 and c_compiler_version == "7.2.*"]
+        - libgfortran-ng {{ libgfortran }}               # [x86_64 and c_compiler_version == "7.2.*"]
+      host:
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                        # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                  # [x86_64 and c_compiler_version == "7.2.*"]
+        - libgfortran-ng {{ libgfortran }}               # [x86_64 and c_compiler_version == "7.2.*"]
       run:
         - {{ pin_subpackage('libopencv', exact=True) }}
         - {{ pin_subpackage('py-opencv', exact=True) }}
@@ -118,9 +138,18 @@ outputs:
     requirements:
       # There is no build script, but I just want it to think
       # that it needs python and numpy at build time
+      build:
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                   # [x86_64 and c_compiler_version == "7.2.*"]
+        - libgfortran-ng {{ libgfortran }}                # [x86_64 and c_compiler_version == "7.2.*"]
       host:
         - python {{python}}
         - numpy {{numpy}}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}                         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}                   # [x86_64 and c_compiler_version == "7.2.*"]
+        - libgfortran-ng {{ libgfortran }}                # [x86_64 and c_compiler_version == "7.2.*"]
       run:
         - python {{python}}
         - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 2
+  number: 3
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
@@ -59,10 +59,6 @@ requirements:
     - {{ cdt('libxdamage') }}
     - {{ cdt('libxfixes') }}
     - {{ cdt('libxxf86vm') }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
-    - libgfortran-ng {{ libgfortran }}
   host:
     - python {{python}} 
     - numpy {{numpy}}
@@ -81,11 +77,6 @@ requirements:
     - freetype {{freetype}}
     - protobuf {{ protobuf }}
     - libprotobuf {{ protobuf }}
-    # Use pins to control cos6/cos7 match
-    - libidn2  2.3.1   #[x86_64]
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
-    - libgfortran-ng {{ libgfortran }}
   run:
     # Don't depend on python in the run section
     # py-opencv will depend on python
@@ -110,16 +101,6 @@ outputs:
     build:
       string: py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
     requirements:
-      build:
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
-      host:
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
       run:
         - {{ pin_subpackage('libopencv', exact=True) }}
         - {{ pin_subpackage('py-opencv', exact=True) }}
@@ -137,18 +118,9 @@ outputs:
     requirements:
       # There is no build script, but I just want it to think
       # that it needs python and numpy at build time
-      build:
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
       host:
         - python {{python}}
         - numpy {{numpy}}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
       run:
         - python {{python}}
         - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
