### PR TITLE
[1.2] pin zlib and openh264 to fix build failure

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     folder: opencv_contrib
 
 build:
-  number: 9
+  number: 10
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   run_exports:
     # https://abi-laboratory.pro/index.php?view=timeline&l=opencv
@@ -59,6 +59,7 @@ requirements:
     - {{ cdt('libxdamage') }}
     - {{ cdt('libxfixes') }}
     - {{ cdt('libxxf86vm') }}
+    - zlib {{ zlib }} h7b6447c_3
     # Use pins to control cos6/cos7 match
     - libgcc-ng  {{ libgcc }}
     - libstdcxx-ng  {{ libstdcxx }}
@@ -69,7 +70,8 @@ requirements:
     - hdf5 {{hdf5}}
     - eigen {{eigen}}
     - jasper {{jasper}} h07fcdf6_1
-    - zlib {{zlib}}
+    - openh264 2.1.0
+    - zlib {{zlib}} h7b6447c_3
     - jpeg {{jpeg}}
     - libtiff {{libtiff}}
     - libwebp


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Update recipe to use: 

- `openh264 v2.1.0`
-  `zlib v1.2.11 h7b6447c_3 `

as the newer versions (released recently) of these packages  are leading to build failure.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
